### PR TITLE
Iterator function doesn't accept the arguments object.

### DIFF
--- a/transpiler/core/standardVars.js
+++ b/transpiler/core/standardVars.js
@@ -61,6 +61,7 @@ const $getIteratorBody =
 	"(v){" +
 		"if(v){" +
 			"if(Array.isArray(v))return 0;" +
+			"if(v.length && v.callee)return ${slice}(v);" + // probably arguments object
 			"var f;" +
 			"if(${Symbol_mark})${Symbol_mark}(v);" +
 			"if(typeof v==='object'&&typeof (f=v[${Symbol_iterator}])==='function'){if(${Symbol_mark})${Symbol_mark}(void 0);return f.call(v);}" +
@@ -74,6 +75,7 @@ const $callIteratorBody =
 	"(v,f){" +
 		"if(v){" +
 			"if(Array.isArray(v))return f?v.slice():v;" +
+			"if(v.length && v.callee)return ${slice}(v);" + //probably arguments
 			"var i,r;"+
 			"if(${Symbol_mark})${Symbol_mark}(v);" +
 			"if(typeof v==='object'&&typeof (f=v[${Symbol_iterator}])==='function'){" +
@@ -151,13 +153,13 @@ var standardVars = {
 	, "Symbol_mark": {template: $SymbolPolyfillMarkBody, name: "S_MARK"}
 	, "getIterator": {
 		template: $getIteratorBody
-		, deps: ["Symbol_iterator", "Symbol_mark"]
+		, deps: ["Symbol_iterator", "Symbol_mark", "slice"]
 		, name: "GET_ITER"
 		, isFunction: true
 	}
 	, "callIterator": {
 		template: $callIteratorBody
-		, deps: ["Symbol_iterator", "Symbol_mark"]
+		, deps: ["Symbol_iterator", "Symbol_mark", "slice"]
 		, name: "ITER"
 		, isFunction: true
 	}

--- a/transpiler/core/standardVars.js
+++ b/transpiler/core/standardVars.js
@@ -61,7 +61,7 @@ const $getIteratorBody =
 	"(v){" +
 		"if(v){" +
 			"if(Array.isArray(v))return 0;" +
-			"if(v.length && v.callee)return ${slice}(v);" + // probably arguments object
+			"if({}.toString.call(v) == '[object Arguments]')return ${slice}.call(v, 0);" + // probably arguments object
 			"var f;" +
 			"if(${Symbol_mark})${Symbol_mark}(v);" +
 			"if(typeof v==='object'&&typeof (f=v[${Symbol_iterator}])==='function'){if(${Symbol_mark})${Symbol_mark}(void 0);return f.call(v);}" +
@@ -75,7 +75,7 @@ const $callIteratorBody =
 	"(v,f){" +
 		"if(v){" +
 			"if(Array.isArray(v))return f?v.slice():v;" +
-			"if(v.length && v.callee)return ${slice}(v);" + //probably arguments
+			"if({}.toString.call(v) == '[object Arguments]')return ${slice}.call(v, 0);" + //probably arguments
 			"var i,r;"+
 			"if(${Symbol_mark})${Symbol_mark}(v);" +
 			"if(typeof v==='object'&&typeof (f=v[${Symbol_iterator}])==='function'){" +


### PR DESCRIPTION
Currently the implementation of the iterator protocol doesn't accept an Arguments object.

Testcase:

``` javascript
function test() {
    console.log(...arguments);
}
test(1, 2, 3); // => should print "1 2 3"
```

This PR is one solution to the problem. I would have updated the tests, but there are too many to do by hand.
