### PR TITLE
Add ";" after return statement for Arrow functions

### DIFF
--- a/transpiler/functions.js
+++ b/transpiler/functions.js
@@ -151,7 +151,7 @@ var plugin = module.exports = {
 					// add { and }
 					this.alter.insertBefore(fnBodyStart, "{", {extend: true});
 //					this.alter.insertBefore(fnBodyEnd, "}", {extend: true});
-					this.alter.insert(fnBodyEnd, "}");
+					this.alter.insert(fnBodyEnd, ";}");
 
 					if( fnBodyHasHiddenBrackets ) {
 						// => (1)   ->   {return 1}


### PR DESCRIPTION
Otherwise, people using jshint can get warnings after transpilation.
