### PR TITLE
make .contains() methods non-enumerable

### DIFF
--- a/es6-transpiler.js
+++ b/es6-transpiler.js
@@ -3,7 +3,7 @@
 
 require("es5-shim");
 require("es6-shim");
-polifills();
+polyfills();
 
 var MIXIN = function(t,s) {
 	for(var p in s) {
@@ -318,16 +318,20 @@ function outputToConsole(output, config) {
 	process.exit(0);
 }
 
-function polifills() {
-	if ( !Array.prototype.contains ) {
-		Array.prototype.contains = function(from) {
-			return !!~this.indexOf(from);
-		}
+function polyfills() {
+	var contains = (from) {
+		return !!~this.indexOf(from);
+	};
+
+	if (!Array.prototype.contains) {
+		Object.defineProperty(Array.prototype, 'contains', {
+			value: contains
+		});
 	}
 
-	if ( !String.prototype.contains ) {
-		String.prototype.contains = function(from) {
-			return !!~this.indexOf(from);
-		}
+	if (!String.prototype.contains) {
+		Object.defineProperty(String.prototype, 'contains', {
+			value: contains
+		});
 	}
 }


### PR DESCRIPTION
This makes the polyfilled `Array.prototype.contains` and `String.prototype.contains` methods non-enumerable, which was causing issues when es6-transpiler and 6to5 are used in the same project (https://github.com/6to5/gobble-6to5/pull/1). I've only edited the source file, I wasn't immediately sure what was involved in rebuilding. Thanks
